### PR TITLE
bugfix: _setupPainter painting before animation

### DIFF
--- a/lib/src/circular_slider.dart
+++ b/lib/src/circular_slider.dart
@@ -173,8 +173,10 @@ class _SleekCircularSliderState extends State<SleekCircularSlider>
     var defaultAngle = _currentAngle ?? widget.angle;
     if (_oldWidgetAngle != null) {
       if (_oldWidgetAngle != widget.angle) {
-        _selectedAngle = null;
-        defaultAngle = widget.angle;
+        _selectedAngle = null;        
+        if(_animationManager == null) {
+          defaultAngle = widget.angle;
+        }
       }
     }
 


### PR DESCRIPTION
_setupPainter was painting value immediately after external changes prior to animation being rendered, causing a glittery transition during animation start.